### PR TITLE
README.md with simpler installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,8 @@ A simple, fast and interruptable download accelerator, written in Rust
 ## Installation
 
 1. Please to install Rust and Cargo using [rustup](https://www.rustup.rs/), and choose the _Nightly_ version ;
-2. Download _Snatch_: `git clone https://github.com/derniercri/snatch` ;
-3. Move in the project: `cd snatch` ;
-4. Install _Snatch_ using `Cargo`: `cargo install` ;
-5. Enjoy !
+2. Install _Snatch_: `cargo install --git https://github.com/derniercri/snatch.git` ;
+3. Enjoy !
 
 ## Usage
 


### PR DESCRIPTION
The cargo `install` command allows for installation from a git repository