### PR TITLE
[#57] Add authorization prompts for Basic Authorization

### DIFF
--- a/src/authorization.rs
+++ b/src/authorization.rs
@@ -1,0 +1,106 @@
+use hyper::header::{Authorization, Basic, Headers, Scheme};
+use std::fmt::{Display, Formatter, Result};
+use std::marker::PhantomData;
+use std::str::FromStr;
+
+/// Enum for the different types of authorization required by a remote document.
+#[derive(Clone)]
+pub enum AuthorizationType {
+    Basic,
+    Digest,
+    Unknown,
+}
+
+/// Trait to extend functionalities of the Headers type, from `hyper`
+pub trait GetAuthorizationType {
+    /// Function to get the authorization type (if any) of a remote document.
+    /// The returned type is `Option<AuthorizationType>`.
+    fn get_authorization_type(&self) -> Option<AuthorizationType>;
+}
+
+impl GetAuthorizationType for Headers {
+    /// Function to get the `WWW-Authenticate` container, from a given header.
+    /// This function returns an Option that contains a `AuthorizationType` type.
+    fn get_authorization_type(&self) -> Option<AuthorizationType> {
+        match self.get_raw("WWW-Authenticate") {
+            Some(raw) => {
+                let header_content = String::from_utf8(raw.get(0).unwrap().clone()).unwrap();
+                let mut header_parts = header_content.split(" ");
+
+                let auth_type = match header_parts.next() {
+                    Some(part) => {
+                        match part {
+                            "Basic" => AuthorizationType::Basic,
+                            "Digest" => AuthorizationType::Digest,
+                            _ => AuthorizationType::Unknown,
+                        }
+                    }
+                    None => return None,
+                };
+                Some(auth_type)
+            }
+            None => None,
+        }
+    }
+}
+
+impl Display for AuthorizationType {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        match self {
+            &AuthorizationType::Basic => write!(f, "Basic"),
+            &AuthorizationType::Digest => write!(f, "Digest"),
+            _ => write!(f, "Unknown"),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct AuthorizationHeaderFactory {
+    authorization_type: AuthorizationType,
+    username: String,
+    password: Option<String>,
+}
+
+impl AuthorizationHeaderFactory {
+    pub fn new(authorization_type: AuthorizationType,
+               username: String,
+               password: Option<String>)
+               -> AuthorizationHeaderFactory {
+        AuthorizationHeaderFactory {
+            authorization_type: authorization_type,
+            username: username,
+            password: password,
+        }
+    }
+
+    pub fn build_header(&self) -> Authorization<String> {
+        match self.authorization_type {
+            AuthorizationType::Basic => Authorization(format!("Basic {}", self)),
+            _ => {
+                panic!("{} Authorization is not supported!",
+                       self.authorization_type)
+            }
+        }
+    }
+}
+
+impl Display for AuthorizationHeaderFactory {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        match self.authorization_type {
+            AuthorizationType::Basic => {
+                let basic_auth = Basic {
+                    username: self.username.clone(),
+                    password: self.password.clone(),
+                };
+                basic_auth.fmt_scheme(f)
+            }
+            _ => {
+                if let Some(ref passwd) = self.password {
+                    write!(f, "{}:{}", self.username, passwd)
+                } else {
+                    write!(f, "{}", self.username)
+                }
+            }
+        }
+    }
+}

--- a/src/authorization.rs
+++ b/src/authorization.rs
@@ -1,7 +1,5 @@
 use hyper::header::{Authorization, Basic, Headers, Scheme};
 use std::fmt::{Display, Formatter, Result};
-use std::marker::PhantomData;
-use std::str::FromStr;
 
 /// Enum for the different types of authorization required by a remote document.
 #[derive(Clone)]

--- a/src/client.rs
+++ b/src/client.rs
@@ -10,6 +10,13 @@ pub trait GetResponse {
     /// ressources and informations)
     fn get_head_response(&self, url: &str) -> Result<Response, Error>;
 
+    /// Given a specific URL and an header, get the header without the content body (useful to not
+    /// waste time, ressources and informations)
+    fn get_head_response_using_headers(&self,
+                                       url: &str,
+                                       header: Headers)
+                                       -> Result<Response, Error>;
+
     /// Given a specific URL, get the response from the target server
     fn get_http_response(&self, url: &str) -> Result<Response, Error>;
 
@@ -23,6 +30,13 @@ pub trait GetResponse {
 impl GetResponse for Client {
     fn get_head_response(&self, url: &str) -> Result<Response, Error> {
         self.request(Method::Head, url).send()
+    }
+
+    fn get_head_response_using_headers(&self,
+                                       url: &str,
+                                       custom_header: Headers)
+                                       -> Result<Response, Error> {
+        self.request(Method::Head, url).headers(custom_header).send()
     }
 
     fn get_http_response(&self, url: &str) -> Result<Response, Error> {

--- a/src/download.rs
+++ b/src/download.rs
@@ -4,7 +4,7 @@ use write::{OutputFileWriter, OutputChunkWriter};
 use client::GetResponse;
 use hyper::client::Client;
 use hyper::error::Error;
-use hyper::header::{ByteRangeSpec, Headers, Range, Scheme};
+use hyper::header::{ByteRangeSpec, Headers, Range};
 use pbr::{MultiBar, Pipe, ProgressBar, Units};
 use response::CheckResponseStatus;
 use std::cmp::min;
@@ -54,13 +54,11 @@ fn get_header_from_index(chunk_index: u64,
                          global_chunk_length: Bytes)
                          -> Option<(Headers, RangeBytes)> {
 
-    get_chunk_length(chunk_index, content_length, global_chunk_length).map(
-        |range| {
-            let mut header = Headers::new();
-            header.set(Range::Bytes(vec![ByteRangeSpec::FromTo(range.0, range.1)]));
-            (header, RangeBytes(range.0, range.1 - range.0))
-        }
-    )
+    get_chunk_length(chunk_index, content_length, global_chunk_length).map(|range| {
+        let mut header = Headers::new();
+        header.set(Range::Bytes(vec![ByteRangeSpec::FromTo(range.0, range.1)]));
+        (header, RangeBytes(range.0, range.1 - range.0))
+    })
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ extern crate pbr;
 
 use std::sync::{Arc, Mutex};
 
+pub mod authorization;
 pub mod client;
 pub mod contentlength;
 pub mod download;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ extern crate num_cpus;
 use ansi_term::Colour::{Green, Yellow, Red, White};
 use clap::{App, Arg};
 use hyper::client::Client;
-use hyper::header::{Authorization, Basic, Headers};
+use hyper::header::Headers;
 use libsnatch::authorization::{AuthorizationHeaderFactory, AuthorizationType, GetAuthorizationType};
 use libsnatch::Bytes;
 use libsnatch::client::GetResponse;
@@ -58,9 +58,8 @@ fn main() {
 
     let url = argparse.value_of("url").unwrap();
 
-    let file = argparse.value_of("file").unwrap_or_else(
-        || url.split('/').last().unwrap_or(DEFAULT_FILENAME)
-    );
+    let file = argparse.value_of("file")
+        .unwrap_or_else(|| url.split('/').last().unwrap_or(DEFAULT_FILENAME));
 
     let threads: usize = value_t!(argparse, "threads", usize).unwrap_or(num_cpus::get_physical());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,10 +5,12 @@ extern crate hyper;
 extern crate libsnatch;
 extern crate num_cpus;
 
-use ansi_term::Colour::{Green, Yellow, Red};
+use ansi_term::Colour::{Green, Yellow, Red, White};
 use clap::{App, Arg};
 use hyper::client::Client;
-use libsnatch::{Bytes};
+use hyper::header::{Authorization, Basic, Headers};
+use libsnatch::authorization::{AuthorizationHeaderFactory, AuthorizationType, GetAuthorizationType};
+use libsnatch::Bytes;
 use libsnatch::client::GetResponse;
 use libsnatch::contentlength::GetContentLength;
 use libsnatch::download::download_chunks;
@@ -16,6 +18,7 @@ use libsnatch::http_version::ValidateHttpVersion;
 use libsnatch::write::OutputFileWriter;
 use std::fs::File;
 use std::io;
+use std::io::Write;
 use std::path::Path;
 use std::process::exit;
 
@@ -87,6 +90,41 @@ fn main() {
         println!("{}", Green.bold().paint("OK !"));
     }
 
+    let auth_type = client_response.headers.get_authorization_type();
+    let auth_header_factory = match auth_type {
+        Some(a_type) => {
+            match a_type {
+                AuthorizationType::Basic => {
+                    println!("{}",
+                             Yellow.bold().paint("The remote content is protected by Basic Auth."));
+                    let username = prompt_user(White.bold(), "Username:");
+                    let password = prompt_user(White.bold(), "Password:");
+                    Some(AuthorizationHeaderFactory::new(AuthorizationType::Basic,
+                                                         username,
+                                                         Some(password)))
+                }
+                _ => {
+                    println!("{}",
+                             Red.bold()
+                                 .paint(format!("[ERROR] The remote content is protected by {} \
+                                                 Authorization, which is not supported!",
+                                                a_type)));
+                    exit(1);
+                }
+            }
+        }
+        None => None,
+    };
+
+    let client_response = match auth_header_factory.clone() {
+        Some(header_factory) => {
+            let mut headers = Headers::new();
+            headers.set(header_factory.build_header());
+            hyper_client.get_head_response_using_headers(&url, headers).unwrap()
+        }
+        None => client_response,
+    };
+
     let local_path = Path::new(&file);
 
     if local_path.exists() {
@@ -96,25 +134,16 @@ fn main() {
                         and is a directory!"));
         }
         if !argparse.is_present("force") {
+            let user_input = prompt_user(Yellow.bold(),
+                                         "[WARNING] The path to store the file already exists! \
+                                          Do you want to override it? [y/N]");
+
+            if !(user_input == "y" || user_input == "Y") {
+                exit(0);
+            }
+        } else {
             println!("{}",
                      Yellow.bold()
-                         .paint("[WARNING] The path to store the file already exists! Do you want \
-                                 to override it? [y/N]"));
-            {
-                let mut user_input = String::new();
-                io::stdin()
-                    .read_line(&mut user_input)
-                    .ok()
-                    .expect("[ERROR] Couldn't read line!");
-                user_input = String::from(user_input.trim());
-                if !(user_input == "y" || user_input == "Y") {
-                    exit(0);
-                }
-            }
-        }
-        else {
-            println!("{}",
-                    Yellow.bold()
                          .paint("[WARNING] The path to store the file already exists! \
                                  It is going to be overriden."));
         }
@@ -140,10 +169,26 @@ fn main() {
         .expect("[ERROR] Cannot extend file to download size!");
     let out_file = OutputFileWriter::new(local_file);
 
-    download_chunks(remote_content_length, out_file, threads as u64, &url);
+    download_chunks(remote_content_length,
+                    out_file,
+                    threads as u64,
+                    &url,
+                    auth_header_factory);
 
     println!("{} Your download is available in {}",
              Green.bold().paint("Done!"),
              local_path.to_str().unwrap());
 
+}
+
+fn prompt_user(style: ansi_term::Style, prompt: &str) -> String {
+    print!("{} ", style.paint(prompt));
+    io::stdout().flush().expect("[ERROR] Couldn't flush stdout!");
+
+    let mut user_input = String::new();
+    io::stdin()
+        .read_line(&mut user_input)
+        .ok()
+        .expect("[ERROR] Couldn't read line!");
+    String::from(user_input.trim())
 }


### PR DESCRIPTION
Fixes #57

For Basic Auth:
```
snatch https://httpbin.org/basic-auth/user/passwd -d
# [DEBUG_MODE] version: 0.1.2
# [DEBUG_MODE] file: passwd
# [DEBUG_MODE] threads: 4
# Waiting a response from the remote server... OK !
The remote content is protected by Basic Auth.
Username: user
Password: passwd
...
```

For Digest Auth or other unsupported auth types:
```
snatch https://httpbin.org/digest-auth/qop/user/passwd -d
# [DEBUG_MODE] version: 0.1.2
# [DEBUG_MODE] file: passwd
# [DEBUG_MODE] threads: 4
# Waiting a response from the remote server... OK !
[ERROR] The remote content is protected by Digest Authorization, which is not supported!
```